### PR TITLE
refactor: use node equality for descendant lookup

### DIFF
--- a/sooqha-docs/lib/tiptap-utils.ts
+++ b/sooqha-docs/lib/tiptap-utils.ts
@@ -188,9 +188,7 @@ export function findNodePosition(props: {
     let foundNode: TiptapNode | null = null
 
     editor.state.doc.descendants((currentNode, pos) => {
-      // TODO: Needed?
-      // if (currentNode.type && currentNode.type.name === node!.type.name) {
-      if (currentNode === node) {
+      if (currentNode.eq(node!)) {
         foundPos = pos
         foundNode = currentNode
         return false


### PR DESCRIPTION
## Summary
- use `currentNode.eq(node)` to match nodes when finding positions
- remove stale comparison TODO

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: ESLint errors in unrelated files)


------
https://chatgpt.com/codex/tasks/task_e_688de7151e1883219e6c8ca8b4398c9d