### PR TITLE
fix: compare Tiptap nodes using eq

### DIFF
--- a/sooqha-docs/lib/tiptap-utils.ts
+++ b/sooqha-docs/lib/tiptap-utils.ts
@@ -188,9 +188,7 @@ export function findNodePosition(props: {
     let foundNode: TiptapNode | null = null
 
     editor.state.doc.descendants((currentNode, pos) => {
-      // TODO: Needed?
-      // if (currentNode.type && currentNode.type.name === node!.type.name) {
-      if (currentNode === node) {
+      if (currentNode.eq(node!)) {
         foundPos = pos
         foundNode = currentNode
         return false


### PR DESCRIPTION
## Summary
- ensure `findNodePosition` compares nodes via `eq`
- remove outdated TODO comment

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: An interface declaring no members is equivalent to its supertype; Unexpected any; react/no-unescaped-entities)*

------
https://chatgpt.com/codex/tasks/task_e_688de70b06a48321a1a14cfb6c6b01fa