### PR TITLE
refactor: centralize cn helper

### DIFF
--- a/sooqha-docs/components/tiptap-ui-primitive/button/button.tsx
+++ b/sooqha-docs/components/tiptap-ui-primitive/button/button.tsx
@@ -10,7 +10,8 @@ import {
 } from "@/components/tiptap-ui-primitive/tooltip"
 
 // --- Lib ---
-import { cn, parseShortcutKeys } from "@/lib/tiptap-utils"
+import { parseShortcutKeys } from "@/lib/tiptap-utils"
+import { cn } from "@/lib/utils"
 
 import "@/components/tiptap-ui-primitive/button/button-colors.scss"
 import "@/components/tiptap-ui-primitive/button/button-group.scss"

--- a/sooqha-docs/components/tiptap-ui-primitive/card/card.tsx
+++ b/sooqha-docs/components/tiptap-ui-primitive/card/card.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import * as React from "react"
-import { cn } from "@/lib/tiptap-utils"
+import { cn } from "@/lib/utils"
 import "@/components/tiptap-ui-primitive/card/card.scss"
 
 const Card = React.forwardRef<HTMLDivElement, React.ComponentProps<"div">>(

--- a/sooqha-docs/components/tiptap-ui-primitive/dropdown-menu/dropdown-menu.tsx
+++ b/sooqha-docs/components/tiptap-ui-primitive/dropdown-menu/dropdown-menu.tsx
@@ -2,7 +2,7 @@
 
 import * as React from "react"
 import * as DropdownMenuPrimitive from "@radix-ui/react-dropdown-menu"
-import { cn } from "@/lib/tiptap-utils"
+import { cn } from "@/lib/utils"
 import "@/components/tiptap-ui-primitive/dropdown-menu/dropdown-menu.scss"
 
 function DropdownMenu({

--- a/sooqha-docs/components/tiptap-ui-primitive/input/input.tsx
+++ b/sooqha-docs/components/tiptap-ui-primitive/input/input.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import * as React from "react"
-import { cn } from "@/lib/tiptap-utils"
+import { cn } from "@/lib/utils"
 import "@/components/tiptap-ui-primitive/input/input.scss"
 
 function Input({ className, type, ...props }: React.ComponentProps<"input">) {

--- a/sooqha-docs/components/tiptap-ui-primitive/popover/popover.tsx
+++ b/sooqha-docs/components/tiptap-ui-primitive/popover/popover.tsx
@@ -2,7 +2,7 @@
 
 import * as React from "react"
 import * as PopoverPrimitive from "@radix-ui/react-popover"
-import { cn } from "@/lib/tiptap-utils"
+import { cn } from "@/lib/utils"
 import "@/components/tiptap-ui-primitive/popover/popover.scss"
 
 function Popover({

--- a/sooqha-docs/components/tiptap-ui-primitive/separator/separator.tsx
+++ b/sooqha-docs/components/tiptap-ui-primitive/separator/separator.tsx
@@ -2,7 +2,7 @@
 
 import * as React from "react"
 import "@/components/tiptap-ui-primitive/separator/separator.scss"
-import { cn } from "@/lib/tiptap-utils"
+import { cn } from "@/lib/utils"
 
 export type Orientation = "horizontal" | "vertical"
 

--- a/sooqha-docs/components/tiptap-ui-primitive/toolbar/toolbar.tsx
+++ b/sooqha-docs/components/tiptap-ui-primitive/toolbar/toolbar.tsx
@@ -3,7 +3,7 @@
 import * as React from "react"
 import { Separator } from "@/components/tiptap-ui-primitive/separator"
 import "@/components/tiptap-ui-primitive/toolbar/toolbar.scss"
-import { cn } from "@/lib/tiptap-utils"
+import { cn } from "@/lib/utils"
 
 type BaseProps = React.HTMLAttributes<HTMLDivElement>
 

--- a/sooqha-docs/lib/tiptap-utils.ts
+++ b/sooqha-docs/lib/tiptap-utils.ts
@@ -1,6 +1,9 @@
 import type { Node as TiptapNode } from "@tiptap/pm/model"
 import { NodeSelection } from "@tiptap/pm/state"
 import type { Editor } from "@tiptap/react"
+import { cn } from "@/lib/utils"
+
+export { cn }
 
 export const MAX_FILE_SIZE = 5 * 1024 * 1024 // 5MB
 
@@ -12,11 +15,6 @@ export const MAC_SYMBOLS: Record<string, string> = {
   backspace: "Del",
 } as const
 
-export function cn(
-  ...classes: (string | boolean | undefined | null)[]
-): string {
-  return classes.filter(Boolean).join(" ")
-}
 
 /**
  * Determines if the current platform is macOS


### PR DESCRIPTION
## Summary
- centralize the `cn` helper in `lib/utils` and expose through `tiptap-utils`
- use the shared `cn` helper across tiptap UI primitives

## Testing
- `pnpm lint` *(fails: An interface declaring no members is equivalent to its supertype, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_688de7098db08321bbeacf412fc75621