### PR TITLE
fix: match scroll listener capture option

### DIFF
--- a/sooqha-docs/hooks/use-cursor-visibility.ts
+++ b/sooqha-docs/hooks/use-cursor-visibility.ts
@@ -66,7 +66,7 @@ export function useCursorVisibility({
 
     return () => {
       resizeObserver.disconnect()
-      window.removeEventListener("scroll", updateRect)
+      window.removeEventListener("scroll", updateRect, true)
     }
   }, [updateRect])
 


### PR DESCRIPTION
## Summary
- ensure scroll cleanup uses capture flag in `useCursorVisibility`

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: An interface declaring no members is equivalent to its supertype)*

------
https://chatgpt.com/codex/tasks/task_e_688de6a30ac0832182cc2005d8563eb8