### PR TITLE
docs: correct default shortcut key delimiter

### DIFF
--- a/sooqha-docs/lib/tiptap-utils.ts
+++ b/sooqha-docs/lib/tiptap-utils.ts
@@ -52,7 +52,7 @@ export const formatShortcutKey = (
 /**
  * Parses a shortcut key string into an array of formatted key symbols
  * @param shortcutKeys - The string of shortcut keys (e.g., "ctrl-alt-shift")
- * @param delimiter - The delimiter used to split the keys (default: "-")
+ * @param delimiter - The delimiter used to split the keys (default: "+")
  * @param capitalize - Whether to capitalize the keys (default: true)
  * @returns Array of formatted shortcut key symbols
  */


### PR DESCRIPTION
## Summary
- fix `parseShortcutKeys` docstring to document `"+"` as the default delimiter

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: multiple ESLint errors)*

------
https://chatgpt.com/codex/tasks/task_e_688de6aabe8483219d6fa5f899932f2b