### PR TITLE
Fix scroll listener cleanup in cursor visibility hook

### DIFF
--- a/sooqha-docs/hooks/use-cursor-visibility.ts
+++ b/sooqha-docs/hooks/use-cursor-visibility.ts
@@ -66,7 +66,7 @@ export function useCursorVisibility({
 
     return () => {
       resizeObserver.disconnect()
-      window.removeEventListener("scroll", updateRect)
+      window.removeEventListener("scroll", updateRect, true)
     }
   }, [updateRect])
 


### PR DESCRIPTION
## Summary
- ensure useCursorVisibility removes scroll listener with matching capture option

## Testing
- `pnpm lint` *(fails: An interface declaring no members is equivalent to its supertype; command failed with exit code 1)*

------
https://chatgpt.com/codex/tasks/task_e_688de70776508321971c85c774a6421d