### PR TITLE
refactor: improve throttled callback typing

### DIFF
--- a/sooqha-docs/hooks/use-throttled-callback.ts
+++ b/sooqha-docs/hooks/use-throttled-callback.ts
@@ -20,8 +20,7 @@ const defaultOptions: ThrottleSettings = {
  * @param dependencies The dependencies to watch for changes
  * @param options The throttle options
  */
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export function useThrottledCallback<T extends (...args: any[]) => any>(
+export function useThrottledCallback<T extends (...args: unknown[]) => unknown>(
   fn: T,
   wait = 250,
   dependencies: React.DependencyList = [],
@@ -29,12 +28,11 @@ export function useThrottledCallback<T extends (...args: any[]) => any>(
 ): {
   (this: ThisParameterType<T>, ...args: Parameters<T>): ReturnType<T>
   cancel: () => void
-  flush: () => void
+  flush: () => ReturnType<T>
 } {
   const handler = React.useMemo(
-    () => throttle<T>(fn, wait, options),
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    dependencies
+    () => throttle(fn, wait, options),
+    [fn, wait, options, ...dependencies]
   )
 
   useUnmount(() => {


### PR DESCRIPTION
## Summary
- avoid `any` in useThrottledCallback
- track throttle settings and callback in dependencies

## Testing
- `pnpm lint` *(fails: no-unused-vars, no-empty-object-type, no-explicit-any, react/no-unescaped-entities)*

------
https://chatgpt.com/codex/tasks/task_e_688de703e7b88321ab1bf725288ac8c7