### PR TITLE
refactor: update tooltip ref handling

### DIFF
--- a/sooqha-docs/components/tiptap-ui-primitive/tooltip/tooltip.tsx
+++ b/sooqha-docs/components/tiptap-ui-primitive/tooltip/tooltip.tsx
@@ -158,11 +158,10 @@ export const TooltipTrigger = React.forwardRef<
 >(function TooltipTrigger({ children, asChild = false, ...props }, propRef) {
   const context = useTooltipContext()
   const childrenRef = React.isValidElement(children)
-    ? parseInt(React.version, 10) >= 19
-      ? // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        (children as { props: { ref?: React.Ref<any> } }).props.ref
-      : // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        (children as any).ref
+    ? ((children as React.ReactElement & {
+        ref?: React.Ref<HTMLElement>
+      }).ref ??
+      (children.props as { ref?: React.Ref<HTMLElement> }).ref)
     : undefined
   const ref = useMergeRefs([context.refs.setReference, propRef, childrenRef])
 


### PR DESCRIPTION
## Summary
- remove React.version check in tooltip trigger and use feature detection for child refs
- replace any casts with typed `React.Ref`

## Testing
- `npm test` (fails: Missing script "test")
- `pnpm run lint` (fails: rule errors)


------
https://chatgpt.com/codex/tasks/task_e_688de704b8d483218d54c525b3472f78