### PR TITLE
refactor use-unmount hook types

### DIFF
--- a/sooqha-docs/hooks/use-unmount.ts
+++ b/sooqha-docs/hooks/use-unmount.ts
@@ -5,8 +5,9 @@ import { useRef, useEffect } from "react"
  *
  * @param callback Function to be called on component unmount
  */
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export const useUnmount = (callback: (...args: Array<any>) => any) => {
+export const useUnmount = <T extends (...args: unknown[]) => unknown>(
+  callback: (...args: Parameters<T>) => ReturnType<T>
+) => {
   const ref = useRef(callback)
   ref.current = callback
 


### PR DESCRIPTION
## Summary
- tighten `useUnmount` hook types with generics

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: ESLint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_688de7049de883219d8346d44c8d2890