### PR TITLE
style: make AI panel responsive

### DIFF
--- a/sooqha-docs/components/tiptap-ui/ai-panel/ai-panel-content.tsx
+++ b/sooqha-docs/components/tiptap-ui/ai-panel/ai-panel-content.tsx
@@ -36,7 +36,7 @@ export const AiPanelContent: React.FC<AiPanelContentProps> = ({
   onAgent,
   panelClassName,
   height = "auto",
-  width = "320px",
+  width = "100%",
   variant = "side",
   isProcessing,
   currentPrompt,

--- a/sooqha-docs/components/tiptap-ui/ai-panel/ai-panel.scss
+++ b/sooqha-docs/components/tiptap-ui/ai-panel/ai-panel.scss
@@ -22,6 +22,7 @@
   box-shadow: var(--tt-shadow-elevated-md);
   transition: all var(--tt-transition-duration-default) var(--tt-transition-easing-default);
   height: 100%;
+  width: 100%;
   min-height: 300px;
   max-height: 100vh;
 
@@ -56,6 +57,8 @@
 
   /* Side panel variant */
   &.tt-ai-panel--side {
+    width: 100%;
+    max-width: 320px;
     height: auto;
     min-height: 761px;
     max-height: calc(100vh - 2rem);


### PR DESCRIPTION
## Summary
- make AiPanelContent default to full width
- add responsive width rules to AI panel styles

## Testing
- `pnpm lint` *(fails: Unexpected any, react/no-unescaped-entities)*
- `pnpm exec vitest run`


------
https://chatgpt.com/codex/tasks/task_e_688df14a7fa083218b58d7205c96a7d5