### PR TITLE
feat: add aria label to send button

### DIFF
--- a/sooqha-docs/components/tiptap-ui/ai-panel/chat-input.tsx
+++ b/sooqha-docs/components/tiptap-ui/ai-panel/chat-input.tsx
@@ -70,9 +70,11 @@ export const ChatInput: React.FC<ChatInputProps> = ({
         </div>
 
         <button
+          type="button"
           className="tt-ai-panel-chat-input-send-button"
           onClick={handleSubmit}
           disabled={!value.trim() || isProcessing}
+          aria-label="Send message"
         >
           {isProcessing ? (
             <Loader2 className="tt-ai-panel-chat-input-send-button-icon animate-spin" />


### PR DESCRIPTION
## Summary
- improve AI panel chat input accessibility with `aria-label` on send button
- set explicit `type="button"` to avoid unintended form submissions

## Testing
- `npm test -- --run`
- `npx vitest run __tests__/chat-input.a11y.test.tsx`
- `npm run lint` *(fails: Unexpected any, react/no-unescaped-entities, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_688df16b6e9c8321b5d51820a3cdc6e6