### PR TITLE
feat: add maxWidth to ai panel

### DIFF
--- a/sooqha-docs/components/tiptap-ui/ai-panel/ai-panel-content.tsx
+++ b/sooqha-docs/components/tiptap-ui/ai-panel/ai-panel-content.tsx
@@ -36,7 +36,7 @@ export const AiPanelContent: React.FC<AiPanelContentProps> = ({
   onAgent,
   panelClassName,
   height = "auto",
-  width = "320px",
+  width = "clamp(320px, 50vw, 600px)",
   variant = "side",
   isProcessing,
   currentPrompt,
@@ -58,7 +58,7 @@ export const AiPanelContent: React.FC<AiPanelContentProps> = ({
         variant && `tt-ai-panel--${variant}`,
         panelClassName
       )}
-      style={{ height, width }}
+      style={{ height, width, maxWidth: "100%" }}
     >
       <div className="tt-ai-panel-header">
         <div className="tt-ai-panel-header-left">


### PR DESCRIPTION
## Summary
- add maxWidth style with default responsive width using CSS clamp
- ensure AI panel respects small-screen media queries

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688df16b270c8321b2eee835b9ec9e45