### PR TITLE
Fix AI panel layout spacing

### DIFF
--- a/sooqha-docs/components/tiptap-ui/ai-panel/ai-panel.scss
+++ b/sooqha-docs/components/tiptap-ui/ai-panel/ai-panel.scss
@@ -239,9 +239,9 @@
   flex: 1;
   overflow-y: auto;
   overflow-x: hidden;
-  min-height: 100;
+  min-height: 100%;
   position: relative;
-  margin-top: -1.5rem; /* Move up by 8px */
+  margin-top: -0.5rem; /* Move up by ~8px */
 }
 
 .tt-ai-panel-chat {


### PR DESCRIPTION
## Summary
- correct `.tt-ai-panel-content` to use a unit-based min-height
- adjust top margin to avoid overlapping the panel header

## Testing
- `pnpm lint` *(fails: Unexpected any, react/no-unescaped-entities)*
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_688df16926b08321bc2d31eae4b84b07