### PR TITLE
feat: disable browse button

### DIFF
--- a/sooqha-docs/__tests__/chat-input.test.tsx
+++ b/sooqha-docs/__tests__/chat-input.test.tsx
@@ -1,0 +1,25 @@
+import React from 'react'
+import { render, screen } from '@testing-library/react'
+import { describe, it, expect, vi } from 'vitest'
+import { ChatInput } from '@/components/tiptap-ui/ai-panel/chat-input'
+
+describe('ChatInput Browse button', () => {
+  it('is disabled and cannot be activated', () => {
+    render(<ChatInput value="" onChange={() => {}} onSubmit={() => {}} />)
+    const browseButton = screen.getByRole('button', { name: /browse/i })
+
+    // Button is disabled for assistive technologies and pointer interaction
+    expect(browseButton).toBeDisabled()
+
+    // Mouse clicks do not trigger handlers
+    const clickHandler = vi.fn()
+    browseButton.addEventListener('click', clickHandler)
+    browseButton.click()
+    expect(clickHandler).not.toHaveBeenCalled()
+
+    // Disabled button cannot receive focus
+    browseButton.focus()
+    expect(browseButton).not.toHaveFocus()
+  })
+})
+

--- a/sooqha-docs/components/tiptap-ui/ai-panel/ai-panel.scss
+++ b/sooqha-docs/components/tiptap-ui/ai-panel/ai-panel.scss
@@ -682,7 +682,7 @@
     }
   }
 
-  &--disabled {
+  &:disabled {
     opacity: 0.1;
     cursor: not-allowed;
 

--- a/sooqha-docs/components/tiptap-ui/ai-panel/chat-input.tsx
+++ b/sooqha-docs/components/tiptap-ui/ai-panel/chat-input.tsx
@@ -58,7 +58,11 @@ export const ChatInput: React.FC<ChatInputProps> = ({
             <span className="tt-ai-panel-chat-input-action-text">Attach</span>
           </button>
 
-          <button className="tt-ai-panel-chat-input-action-button tt-ai-panel-chat-input-action-button--disabled">
+          <button
+            className="tt-ai-panel-chat-input-action-button"
+            disabled
+            aria-disabled="true"
+          >
             <Globe className="tt-ai-panel-chat-input-action-icon" />
             <span className="tt-ai-panel-chat-input-action-text">Browse</span>
           </button>


### PR DESCRIPTION
## Summary
- disable Browse option in ChatInput using native attributes
- rely on `:disabled` styles for action buttons
- add regression test ensuring Browse stays inactive

## Testing
- `npm test`
- `npm run lint` *(fails: ESLint must be installed)*

------
https://chatgpt.com/codex/tasks/task_e_688df1590c408321a2be8856073a5832